### PR TITLE
fix driver version to 2.37 temporarily

### DIFF
--- a/chrome/setup.go
+++ b/chrome/setup.go
@@ -61,7 +61,8 @@ func SetupDriver() error {
 		return err
 	}
 
-	version := latestRelease()
+	// version := latestRelease()
+	version := "2.37"
 
 	_, err = os.Stat(DriverPath)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
chromedriver 2.38 だと `--version` コマンドが実装されておらず、バージョン確認のステップで止まってしまうので、一時的にバージョンを 2.37 に固定しました。