### PR TITLE
add function wait for enabled or disabled state of element

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,21 +12,21 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run:
-          name: Install Dependencies
+          name: go mod download
           command: go mod download
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
       - run:
-          name: Chack gofmt
+          name: check gofmt
           command: |
             test -z `gofmt -l ./ | tee /dev/stderr | head -n 1`
       - run:
-          name: Chack code
+          name: check go vet
           command: |
             go vet ./...
       - run:
-          name: Run tests
+          name: run tests
           command: |
             go test -v ./...

--- a/element.go
+++ b/element.go
@@ -56,3 +56,39 @@ func (e *Element) VerifyText(fn func(string, string) bool, expect string) *Eleme
 	}
 	return e
 }
+
+func (e *Element) WaitForEnabled() *Element {
+	e.Helper()
+
+	var enabled bool
+	var err error
+	ok := wait(func() bool {
+		enabled, err = e.elem.IsEnabled()
+		if err != nil {
+			e.Fatal(err)
+		}
+		return enabled
+	})
+	if !ok {
+		e.Fatal(err)
+	}
+	return e
+}
+
+func (e *Element) WaitForDisabled() *Element {
+	e.Helper()
+
+	var enabled bool
+	var err error
+	ok := wait(func() bool {
+		enabled, err = e.elem.IsEnabled()
+		if err != nil {
+			e.Fatal(err)
+		}
+		return !enabled
+	})
+	if !ok {
+		e.Fatal(err)
+	}
+	return e
+}

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -27,7 +27,7 @@ func TestSimple(tt *testing.T) {
 	d := t.OpenBrowser()
 	d.SetPageLoadTimeout(4 * time.Second)
 
-	d.VisitTo("https://tour.golang.org/welcome/1")
+	d.VisitTo("https://go.dev/tour/welcome/1")
 	// ngのレンダリングを待たなければrunの結果が出てこない
 	d.TakeSource("./before.html")
 	time.Sleep(2 * time.Second)
@@ -38,9 +38,6 @@ func TestSimple(tt *testing.T) {
 
 	d.WaitFor("class:stdout")
 	d.MustFindElement("class:stdout").VerifyText(strings.Contains, "Hello")
-
-	d.MustFindElement("class:next-page").Click()
-	d.ExpectTransitTo("/welcome/2").TakeScreenshot("page2.png")
 }
 
 var code = `


### PR DESCRIPTION
WaitForEnabled() method will allow webtester to wait for an element to become enabled before interacting with it. This can be useful in cases where an element is initially disabled, such as when a user needs to click on a button to enable it.

For example, if you are testing a website that has a "Login" button, you can use the WaitForEnabled() method to wait for the button to become enabled before clicking on it. This will ensure that you are always testing the website with the button enabled, even if it is initially disabled.