### PR TITLE
update macos platform

### DIFF
--- a/chrome/setup.go
+++ b/chrome/setup.go
@@ -46,7 +46,7 @@ func chromeVersion() (version string) {
 		}
 	}
 	if err != nil {
-		return "90"
+		return "120"
 	}
 	return parseChromeVersion(line)
 }

--- a/chrome/setup.go
+++ b/chrome/setup.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -62,7 +61,7 @@ func latestRelease() (version string) {
 	}
 	defer res.Body.Close()
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return ""
 	}
@@ -130,7 +129,7 @@ func SetupDriver() error {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/GoogleChromeLabs/chrome-for-testing?tab=readme-ov-file#json-api-endpoints

> linux64
mac-arm64
mac-x64
win32
win64

chromeのmacのplatformが`mac64` ではなく、`mac-arm64`, `mac-x64` に変わったので、対応しました。また、default versionを90から120に引き上げました。